### PR TITLE
Week2 project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,3 +75,21 @@ predict:
 .PHONY: run
 run: generate shuffle normalize split train test_model
 
+.PHONY: generate_synonyms_data
+generate_synonyms_data:
+	python `pwd`/week2/createContentTrainingData.py --label name --min_products 500 --output `pwd`/datasets/fasttext/products.txt
+
+.PHONY: normalize_synonyms_data
+normalize_synonyms_data: 
+	cat `pwd`/datasets/fasttext/products.txt |  cut -c 10- | sed -e "s/\([.\!?,'/()]\)/ \1 /g" | tr "[:upper:]" "[:lower:]" | sed "s/[^[:alnum:]]/ /g" | tr -s ' ' > `pwd`/datasets/fasttext/normalized_products.txt
+
+.PHONY: train_synonyms
+train_synonyms: 
+	fasttext skipgram -input `pwd`/datasets/fasttext/normalized_products.txt -output `pwd`/datasets/fasttext/title_model -minCount 10 -epoch 25
+
+.PHONY: predict_synonyms
+predict_synonyms: 
+	fasttext nn `pwd`/datasets/fasttext/title_model.bin
+
+.PHONY: run_synonyms
+run_synonyms: generate_synonyms_data normalize_synonyms_data train_synonyms

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - DISABLE_SECURITY_PLUGIN=true
     volumes:
       - opensearch-machine-learning-data:/usr/share/opensearch/data
+      - ${PWD}/datasets/fasttext/synonyms.csv:/usr/share/opensearch/config/synonyms.csv
     ports:
       - 9200:9200
       - 9600:9600 # required for Performance Analyzer

--- a/week2/Assessment.md
+++ b/week2/Assessment.md
@@ -1,0 +1,261 @@
+# Week2 - Project Assessment
+
+## 1. For classifying product names to categories:
+
+#### a) What precision (P@1) were you able to achieve?
+
+**0.972 - 0.974**
+
+#### b) What fastText parameters did you use?
+
+`-lr 1.0 -epoch 25 -wordNgrams 2`
+
+#### c) How did you transform the product names?
+
+No transformation applied using "transform_name" method. When tested with transformation, achieved lower scores (~0.95).
+
+#### d) How did you prune infrequent category labels, and how did that affect your precision?
+
+Utilising pandas. Removing the category rows that has less than **min_products** products.
+
+It had a huge impact, without pruning: 0.603, with prining: 0.97 - 0.972
+
+#### e) How did you prune the category tree, and how did that affect your precision?
+
+Utilising pandas. Replacing with the **nearest_parent** category that has more than **min_products** products.
+
+It had a smaller impact comparing to pruning (but we are extending our category dictionary), always falling back to ancestors at depth 1: 0.909, final solution: 0.972 - 0.974
+
+## 2. For deriving synonyms from content:
+
+#### a) What were the results for your best model in the tokens used for evaluation?
+
+Product Types
+
+```
+headphones:
+
+headphon 0.848862
+earbud 0.780217
+ear 0.730387
+earpollut 0.691522
+yurbud 0.686955
+phones 0.682976
+cancelling 0.653936
+over 0.639882
+earphon 0.638961
+piiq 0.635533
+```
+
+```
+laptop:
+
+notebook 0.767502
+netbook 0.656412
+bags 0.653984
+ultrabook 0.636491
+zenbook 0.627366
+omnibook 0.620251
+lifebook 0.613478
+ibook 0.611688
+briefcas 0.608474
+t2060 0.602118
+```
+
+```
+freezer:
+
+freezerless 0.890927
+refriger 0.803499
+refrigerators 0.779358
+refrigerator 0.774626
+freez 0.770645
+by 0.713044
+cu 0.665524
+side 0.658299
+satina 0.657314
+frost 0.648286
+```
+
+Brands
+
+```
+nintendo:
+
+ds 0.968273
+wii 0.932205
+3ds 0.810575
+nintendog 0.808966
+gam 0.74554
+xbox 0.720017
+playstat 0.719159
+psp 0.69107
+360 0.676576
+```
+
+```
+whirlpool:
+
+maytag 0.775183
+frigidair 0.771827
+biscuit 0.750548
+ge 0.721097
+ingli 0.694863
+hotpoint 0.687357
+kitchenaid 0.676704
+bisque 0.659302
+electrolux 0.639224
+amana 0.638293
+```
+
+```
+kodak:
+
+easyshar 0.856131
+m341 0.711334
+c813 0.684549
+playsport 0.681347
+m1063 0.677522
+m763 0.676062
+playtouch 0.670581
+m340 0.66795
+m550 0.663166
+```
+
+Models
+
+```
+ps2:
+
+playstat 0.814385
+ps3 0.729845
+xbox 0.720434
+gamecub 0.707921
+guides 0.701105
+psp 0.690421
+gba 0.675813
+gamecube 0.675015
+guid 0.672131
+adventur 0.66446
+```
+
+```
+razr:
+
+motorola 0.803692
+droid 0.719096
+cliphang 0.705777
+cliq 0.704293
+nokia 0.703014
+r225 0.678673
+phone 0.674843
+startac 0.67105
+cell 0.668403
+ccm 0.660618
+```
+
+```
+stratocaster:
+
+telecaster 0.886299
+fretboard 0.81337
+strat 0.7886
+starcaster 0.777565
+fender 0.765122
+squier 0.755677
+tremolo 0.72126
+thinlin 0.71435
+whammy 0.710852
+hss 0.69354
+```
+
+Other
+
+```
+holiday:
+
+nobr 0.671777
+stock 0.660111
+congratul 0.587655
+reindeer 0.585895
+kwanzaa 0.583799
+hallmark 0.578288
+navidad 0.567146
+perfectli 0.566057
+slaphappi 0.554414
+stardol 0.554159
+```
+
+```
+plasma:
+
+panel 0.700569
+flat 0.688087
+edtv 0.686464
+tv 0.684522
+hdtv 0.650581
+ultravis 0.646992
+viera 0.640964
+kuro 0.639569
+xbr 0.633605
+ambilight 0.611085
+```
+
+```
+leather:
+
+reclin 0.682314
+berklin 0.639976
+dolan 0.627329
+sofa 0.621712
+faux 0.608956
+armless 0.605202
+case 0.604042
+folio 0.566838
+theaterseatstor 0.555563
+sleev 0.552663
+```
+
+#### b) What fastText parameters did you use?
+
+`-minCount 7 -epoch 25`, minCount 7 mostly to keep "nespresso", it had 8 occurences.
+
+#### c) How did you transform the product names?
+
+using **nltk word_tokenize, pos_tag, stopwords and stem**
+
+## 3. For integrating synonyms with search:
+
+#### a) How did you transform the product names (if different than previously)?
+
+Same as level 2, using **nltk word_tokenize, pos_tag, stopwords and stem**
+
+#### b) What threshold score did you use?
+
+**0.75**
+
+#### c) Were you able to find the additional results by matching synonyms?
+
+Yes (you can see in "query_results.json" and "query_results_with_synonyms.json")
+
+- "earbuds" => 1205 to 5852
+- "nespresso" => 8 to 265
+- "dslr" => 2837 to 7359
+
+## 4. For classifying reviews:
+
+#### a) What precision (P@1) were you able to achieve?
+
+**0.88**
+
+#### b) What fastText parameters did you use?
+
+`-lr 1.0 -epoch 25 -wordNgrams 2`
+
+#### c) How did you transform the review content?
+
+No transformations. Tried only title or only comments, did not increase the precision.
+
+#### d) How did you transform the review content?
+
+Transforming rating to a different scale “positive”, “negative”, and “neutral” helped. P@1 is increased from **0.671** to **0.88**

--- a/week2/conf/bbuy_products.json
+++ b/week2/conf/bbuy_products.json
@@ -8,6 +8,10 @@
             "smarter_hyphens_filter",
             "lowercase"
           ]
+        },
+        "synonym": {
+          "tokenizer": "whitespace",
+          "filter": [ "lowercase", "stemmer", "synonym" ]
         }
       },
       "tokenizer": {
@@ -24,6 +28,10 @@
           "type": "word_delimiter_graph",
           "catenate_words": true,
           "catenate_all": true
+        },
+        "synonym": {
+          "type": "synonym",
+          "synonyms_path": "synonyms.csv"
         }
       }
     }
@@ -248,8 +256,11 @@
           },
           "suggest": {
             "type": "completion"
+          },
+          "synonyms":{
+            "type": "text",
+            "analyzer": "synonym"
           }
-
         }
       },
       "onSale": {

--- a/week2/createReviewLabels.py
+++ b/week2/createReviewLabels.py
@@ -6,13 +6,20 @@ def transform_training_data(title, comment):
     # IMPLEMENT
     return title + ' ' + comment
 
+def transform_rating(rating):
+    rating_float = float(rating)
+    if rating_float > 3.6:
+        return "positive"
+    elif rating_float < 2.5:
+        return "negative"
+    return "neutral"
 
 # Directory for review data
 directory = r'datasets/product_data/reviews/'
 parser = argparse.ArgumentParser(description='Process some integers.')
 general = parser.add_argument_group("general")
-general.add_argument("--input", default=directory,  help="The directory containing reviews")
-general.add_argument("--output", default="datasets/fasttext/output.fasttext", help="the file to output to")
+general.add_argument("--input", default="datasets/product_data/reviews",  help="The directory containing reviews")
+general.add_argument("--output", default="datasets/fasttext/output_reviews.fasttext", help="the file to output to")
 
 args = parser.parse_args()
 output_file = args.output
@@ -38,4 +45,4 @@ with open(output_file, 'w') as output:
                     elif '<comment>' in line:
                         comment = line[13:len(line) - 11]
                     elif '</review>'in line:
-                      output.write("__label__%s %s\n" % (rating, transform_training_data(title, comment)))
+                        output.write("__label__%s %s\n" % (transform_rating(rating), transform_training_data(title, comment)))

--- a/week2/generateSynonyms.py
+++ b/week2/generateSynonyms.py
@@ -1,0 +1,28 @@
+import argparse
+import fasttext
+import os
+import csv
+
+ROOT_DIR = os.path.dirname(os.path.abspath("__file__"))
+MODEL_PATH = os.path.join(ROOT_DIR, 'datasets/fasttext/title_model.bin')
+TOP_WORDS_PATH = os.path.join(ROOT_DIR, 'datasets/fasttext/top_words.txt')
+OUTPUT_CSV = os.path.join(ROOT_DIR, 'datasets/fasttext/synonyms.csv')
+
+model = fasttext.load_model(path=MODEL_PATH)
+
+parser = argparse.ArgumentParser(description='Process some integers.')
+general = parser.add_argument_group("general")
+general.add_argument("--threshold", default=0.75, type=float, help="The minimum NN score to accept word neighbor word as a synonym (range between 0 - 1)")
+args = parser.parse_args()
+
+with open(TOP_WORDS_PATH) as top_words_file:
+    csv_lines=[]
+    for line in top_words_file:
+        word = line.rstrip()
+        nearest_neighbors = model.get_nearest_neighbors(word)
+        filtered_neighbor_words = [nearest_neighbor[1] for nearest_neighbor in nearest_neighbors if nearest_neighbor[0] > args.threshold]
+        if len(filtered_neighbor_words):
+            csv_lines.append(tuple([word] + filtered_neighbor_words))
+    with open(OUTPUT_CSV, "wt") as synonyms_file:
+        writer = csv.writer(synonyms_file, delimiter=",")
+        writer.writerows(csv_lines)

--- a/week2/query_results.json
+++ b/week2/query_results.json
@@ -1,0 +1,385 @@
+[
+  {
+    "took": 127,
+    "timed_out": false,
+    "_shards": {
+      "total": 1,
+      "successful": 1,
+      "skipped": 0,
+      "failed": 0
+    },
+    "hits": {
+      "total": {
+        "value": 1205,
+        "relation": "eq"
+      },
+      "max_score": 843.09705,
+      "hits": [
+        {
+          "_index": "bbuy_products",
+          "_id": "9084206",
+          "_score": 843.09705,
+          "_source": {
+            "name": [
+              "Apple\u00ae - Earbuds for Select Apple\u00ae iPod\u00ae Models"
+            ],
+            "shortDescription": [
+              "Compatible with 4th-generation iPod nano, 120GB iPod classic and 2nd-generation iPod touch; remote for controlling music and video playback; microphone for recording voice memos"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "2197043",
+          "_score": 121.19351,
+          "_source": {
+            "name": ["Sony - Earbud Headphones - Black"],
+            "shortDescription": [
+              "13.5mm drivers; neodymium magnet; 3 sets of silicone ear cushions"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "3100277",
+          "_score": 109.44192,
+          "_source": {
+            "name": ["Rocketfish\u2122 - Stereo Earbud Headphones"],
+            "shortDescription": [
+              "10mm drivers; neodymium magnets; lightweight design"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "2197089",
+          "_score": 109.428734,
+          "_source": {
+            "name": ["Sony - Earbud Headphones - White"],
+            "shortDescription": [
+              "13.5mm drivers; neodymium magnet; 3 sets of silicone ear cushions"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "8605459",
+          "_score": 99.21863,
+          "_source": {
+            "name": ["JVC - Gumy Stereo Earbud Headphones - Olive Black"],
+            "shortDescription": [
+              "Compatible with most portable audio devices; 3-1/3' cord; gold-plated stereo mini jack"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "3316072",
+          "_score": 98.27057,
+          "_source": {
+            "name": ["JVC - JVC Sport Clip Earbud Headphones - Black"],
+            "shortDescription": [
+              "JVC Sport Clip Earbud Headphones: Rubber ear hooks; water-resistant design; sound isolating; 11mm drivers; neodymium magnets"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "8605253",
+          "_score": 95.65777,
+          "_source": {
+            "name": ["JVC - Gumy Stereo Earbud Headphones - Coconut White"],
+            "shortDescription": [
+              "From our expanded online assortment; compatible with most portable audio devices; 3-1/3' cord; gold-plated stereo mini jack"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "1232474",
+          "_score": 92.01677,
+          "_source": {
+            "name": ["Beats By Dr. Dre - Beats iBeats Earbud Headphones"],
+            "shortDescription": [
+              "3-button microphone; noise-canceling design; Duraflex protective jacket"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "2197052",
+          "_score": 86.037025,
+          "_source": {
+            "name": ["Sony - Earbud Headphones - Dark Blue"],
+            "shortDescription": [
+              "13.5mm drivers; neodymium magnet; 3 sets of silicone ear cushions"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "2264036",
+          "_score": 85.73258,
+          "_source": {
+            "name": ["JayBird - Freedom Bluetooth Earbud Headphones"],
+            "shortDescription": [
+              "GeckoGrip active ear tips; 6 earbud sizes; Bluetooth-ready; sound isolating; tangle-free flat cord; magnet-sealed hard shell carrying case"
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "took": 30,
+    "timed_out": false,
+    "_shards": {
+      "total": 1,
+      "successful": 1,
+      "skipped": 0,
+      "failed": 0
+    },
+    "hits": {
+      "total": {
+        "value": 8,
+        "relation": "eq"
+      },
+      "max_score": 0.07420327,
+      "hits": [
+        {
+          "_index": "bbuy_products",
+          "_id": "3990516",
+          "_score": 0.07420327,
+          "_source": {
+            "name": ["Nespresso - Essenza Espresso Maker - Black"],
+            "shortDescription": [
+              "Makes espresso and lungo; 19-bar high-pressure pump; Thermobloc heating element; Compact Brewing Unit technology; 30-oz. removable water tank; manual volume control; backlit coffee buttons; 1260 watts of power"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "1720059",
+          "_score": 0.07420327,
+          "_source": {
+            "name": ["Nespresso - Essenza Espresso Maker - Black"],
+            "shortDescription": [
+              "Automatic and programmable; compact brewing unit technology; included Aeroccino milk frother; backlit on/off and coffee volume buttons"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "3990589",
+          "_score": 0.07074005,
+          "_source": {
+            "name": ["Nespresso - CitiZ Espresso Maker - Black"],
+            "shortDescription": [
+              "Makes espresso and lungo; 19-bar high-pressure pump; automatic volume control; thermo block heating element; auto power-off after 9 minutes; folding drip tray; removable 34-oz. water tank; adaptable grid"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "3990831",
+          "_score": 0.07074005,
+          "_source": {
+            "name": ["Nespresso - CitiZ Espresso Maker - Red"],
+            "shortDescription": [
+              "Makes espresso and lungo; 19-bar high-pressure pump; automatic volume control; thermo block heating element; auto power-off after 9 minutes; folding drip tray; removable 34-oz. water tank; adaptable grid"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "3990534",
+          "_score": 0.07073941,
+          "_source": {
+            "name": ["Nespresso - Pixie Espresso Maker - Electric Aluminum"],
+            "shortDescription": [
+              "Thermoblock heating element; 19-bar high-pressure pump; automatic volume control; folding drip tray; cable storage"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "3990561",
+          "_score": 0.07073941,
+          "_source": {
+            "name": ["Nespresso - Pixie Espresso Maker - Electric Titan"],
+            "shortDescription": [
+              "Thermoblock heating element; 19-bar high-pressure pump; folding drip tray; cable storage; capsule container"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "2588376",
+          "_score": 0.07073941,
+          "_source": {
+            "name": ["Nespresso - Essenza Espresso Maker - Titan Gray"],
+            "shortDescription": [
+              "Automatic and programmable; compact unit brewing technology; included Aeroccino milk frother; backlit on/off and coffee volume buttons"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "3991039",
+          "_score": 0.06758508,
+          "_source": {
+            "name": ["Nespresso - CitiZ & Milk Coffeemaker - Silver Chrome"],
+            "shortDescription": [
+              "Thermoblock heating element; froths hot or cold milk; 19-bar high-pressure pump; folding drip tray; cable storage"
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "took": 34,
+    "timed_out": false,
+    "_shards": {
+      "total": 1,
+      "successful": 1,
+      "skipped": 0,
+      "failed": 0
+    },
+    "hits": {
+      "total": {
+        "value": 2837,
+        "relation": "eq"
+      },
+      "max_score": 408.17416,
+      "hits": [
+        {
+          "_index": "bbuy_products",
+          "_id": "1980124",
+          "_score": 408.17416,
+          "_source": {
+            "name": [
+              "Canon - EOS Rebel T3i 18.0-Megapixel DSLR Camera with 18-55mm Lens - Black"
+            ],
+            "shortDescription": [
+              "Vari-angle 3.0-inch Clear View LCD screen1080 full HD video3.7 FPS (frames per second)ISO 100-6400 (expandable to 12800)"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "1989073",
+          "_score": 347.9671,
+          "_source": {
+            "name": [
+              "Nikon - D5100 16.2-Megapixel DSLR Camera with 18-55mm VR Lens - Black"
+            ],
+            "shortDescription": [
+              "High Resolution 16.2 MP DX-format CMOS sensor3\" Super-Density Vari-Angle LCD Monitor1080 full HD videoISO sensitivity 100-6400 (expandable to ISO 25,600 equivalent)"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "6813362",
+          "_score": 193.71939,
+          "_source": {
+            "name": ["Canon - DSLR Gadget Bag - Black"],
+            "shortDescription": [
+              "Convenient storage for Canon EOS DSLR cameras"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "2705145",
+          "_score": 27.712948,
+          "_source": {
+            "name": ["DigiPower - Travel Charger"],
+            "shortDescription": [
+              "Compatible with select Canon DSLR batteries; provides uninterrupted power for your digital camera; lightweight design"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "9778635",
+          "_score": 27.528584,
+          "_source": {
+            "name": [
+              "Canon - EOS Rebel T2i 18.0-Megapixel DSLR Camera with EF-S 18-55mm Lens - Black"
+            ],
+            "shortDescription": [
+              "3\" LCD screenFull HD videoISO 100-6400 (expandable to 12800)"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "1223834",
+          "_score": 11.542395,
+          "_source": {
+            "name": [
+              "PNY - 16GB Secure Digital High Capacity (SDHC) Class 10 Memory Card"
+            ],
+            "shortDescription": [
+              "Compatible with most digital cameras and camcorders with a Secure Digital High Capacity slot; 16GB capacity; shock protection and RTV silicone coating"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "1227075",
+          "_score": 10.8557005,
+          "_source": {
+            "name": [
+              "PNY - 8GB Secure Digital High Capacity (SDHC) Class 10 Memory Card"
+            ],
+            "shortDescription": [
+              "Compatible with most digital cameras and camcorders with a Secure Digital High Capacity slot; 8GB capacity; shock protection and RTV silicone coating"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "3099128",
+          "_score": 10.553733,
+          "_source": {
+            "name": [
+              "Nikon - D3100 14.2-Megapixel DSLR Camera with 18-55mm VR Lens - Red"
+            ],
+            "shortDescription": [
+              "3\" TFT-LCD display1080p full HD videoUp to 3 fpsISO 100-3200 (expandable to 12,800)"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "2300602",
+          "_score": 6.7035723,
+          "_source": {
+            "name": [
+              "PNY - 32GB Secure Digital High Capacity (SDHC) Class 10 Memory Card"
+            ],
+            "shortDescription": [
+              "Compatible with most digital cameras with a Secure Digital High Capacity slot; 32GB capacity; 20MB/sec. transfer rate"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "8758114",
+          "_score": 6.677643,
+          "_source": {
+            "name": [
+              "Canon - 55-250mm f/4-5.6 Telephoto Zoom Lens for Select Canon Cameras"
+            ],
+            "shortDescription": [
+              "Compatible with Canon cameras with an EF-S mount; optical image stabilizer maintains clarity at slow shutter speeds; 12 elements in 10 groups"
+            ]
+          }
+        }
+      ]
+    }
+  }
+]

--- a/week2/query_results_with_synonyms.json
+++ b/week2/query_results_with_synonyms.json
@@ -1,0 +1,399 @@
+[
+  {
+    "took": 40,
+    "timed_out": false,
+    "_shards": {
+      "total": 1,
+      "successful": 1,
+      "skipped": 0,
+      "failed": 0
+    },
+    "hits": {
+      "total": {
+        "value": 5852,
+        "relation": "eq"
+      },
+      "max_score": 843.13885,
+      "hits": [
+        {
+          "_index": "bbuy_products",
+          "_id": "9084206",
+          "_score": 843.13885,
+          "_source": {
+            "name": [
+              "Apple\u00ae - Earbuds for Select Apple\u00ae iPod\u00ae Models"
+            ],
+            "shortDescription": [
+              "Compatible with 4th-generation iPod nano, 120GB iPod classic and 2nd-generation iPod touch; remote for controlling music and video playback; microphone for recording voice memos"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "2197043",
+          "_score": 146.2772,
+          "_source": {
+            "name": ["Sony - Earbud Headphones - Black"],
+            "shortDescription": [
+              "13.5mm drivers; neodymium magnet; 3 sets of silicone ear cushions"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "9251098",
+          "_score": 141.56953,
+          "_source": {
+            "name": [
+              "Skullcandy - Ink'd Stereo Ear Bud Headphones - Black/Chrome"
+            ],
+            "shortDescription": [
+              "Ear bud design; silicone ear gels; noise reduction"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "3100277",
+          "_score": 141.23859,
+          "_source": {
+            "name": ["Rocketfish\u2122 - Stereo Earbud Headphones"],
+            "shortDescription": [
+              "10mm drivers; neodymium magnets; lightweight design"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "8605459",
+          "_score": 140.37383,
+          "_source": {
+            "name": ["JVC - Gumy Stereo Earbud Headphones - Olive Black"],
+            "shortDescription": [
+              "Compatible with most portable audio devices; 3-1/3' cord; gold-plated stereo mini jack"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "3316072",
+          "_score": 139.03253,
+          "_source": {
+            "name": ["JVC - JVC Sport Clip Earbud Headphones - Black"],
+            "shortDescription": [
+              "JVC Sport Clip Earbud Headphones: Rubber ear hooks; water-resistant design; sound isolating; 11mm drivers; neodymium magnets"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "8605253",
+          "_score": 135.33597,
+          "_source": {
+            "name": ["JVC - Gumy Stereo Earbud Headphones - Coconut White"],
+            "shortDescription": [
+              "From our expanded online assortment; compatible with most portable audio devices; 3-1/3' cord; gold-plated stereo mini jack"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "2204196",
+          "_score": 134.36525,
+          "_source": {
+            "name": ["Sony - Over-The-Ear Headphones - Black"],
+            "shortDescription": [
+              "30mm multilayer dome diaphragm; high-energy neodymium driver; urethane-cushioned ear pads"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "2197089",
+          "_score": 132.07745,
+          "_source": {
+            "name": ["Sony - Earbud Headphones - White"],
+            "shortDescription": [
+              "13.5mm drivers; neodymium magnet; 3 sets of silicone ear cushions"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "1232474",
+          "_score": 130.18471,
+          "_source": {
+            "name": ["Beats By Dr. Dre - Beats iBeats Earbud Headphones"],
+            "shortDescription": [
+              "3-button microphone; noise-canceling design; Duraflex protective jacket"
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "took": 28,
+    "timed_out": false,
+    "_shards": {
+      "total": 1,
+      "successful": 1,
+      "skipped": 0,
+      "failed": 0
+    },
+    "hits": {
+      "total": {
+        "value": 265,
+        "relation": "eq"
+      },
+      "max_score": 4.3011093,
+      "hits": [
+        {
+          "_index": "bbuy_products",
+          "_id": "2473053",
+          "_score": 4.3011093,
+          "_source": {
+            "name": ["Dynex\u2122 - Espresso Basic Stand for TVs Up to 32\""],
+            "shortDescription": [
+              "Accommodates up to 3 full-size components; additional storage for game consoles; 1 adjustable shelf; particle board; slide-on moldings; wire management"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "3990516",
+          "_score": 0.074202724,
+          "_source": {
+            "name": ["Nespresso - Essenza Espresso Maker - Black"],
+            "shortDescription": [
+              "Makes espresso and lungo; 19-bar high-pressure pump; Thermobloc heating element; Compact Brewing Unit technology; 30-oz. removable water tank; manual volume control; backlit coffee buttons; 1260 watts of power"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "1720059",
+          "_score": 0.074202724,
+          "_source": {
+            "name": ["Nespresso - Essenza Espresso Maker - Black"],
+            "shortDescription": [
+              "Automatic and programmable; compact brewing unit technology; included Aeroccino milk frother; backlit on/off and coffee volume buttons"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "3990589",
+          "_score": 0.0707395,
+          "_source": {
+            "name": ["Nespresso - CitiZ Espresso Maker - Black"],
+            "shortDescription": [
+              "Makes espresso and lungo; 19-bar high-pressure pump; automatic volume control; thermo block heating element; auto power-off after 9 minutes; folding drip tray; removable 34-oz. water tank; adaptable grid"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "3990831",
+          "_score": 0.0707395,
+          "_source": {
+            "name": ["Nespresso - CitiZ Espresso Maker - Red"],
+            "shortDescription": [
+              "Makes espresso and lungo; 19-bar high-pressure pump; automatic volume control; thermo block heating element; auto power-off after 9 minutes; folding drip tray; removable 34-oz. water tank; adaptable grid"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "3990534",
+          "_score": 0.07073936,
+          "_source": {
+            "name": ["Nespresso - Pixie Espresso Maker - Electric Aluminum"],
+            "shortDescription": [
+              "Thermoblock heating element; 19-bar high-pressure pump; automatic volume control; folding drip tray; cable storage"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "3990561",
+          "_score": 0.07073936,
+          "_source": {
+            "name": ["Nespresso - Pixie Espresso Maker - Electric Titan"],
+            "shortDescription": [
+              "Thermoblock heating element; 19-bar high-pressure pump; folding drip tray; cable storage; capsule container"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "2588376",
+          "_score": 0.07073936,
+          "_source": {
+            "name": ["Nespresso - Essenza Espresso Maker - Titan Gray"],
+            "shortDescription": [
+              "Automatic and programmable; compact unit brewing technology; included Aeroccino milk frother; backlit on/off and coffee volume buttons"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "3991039",
+          "_score": 0.06758291,
+          "_source": {
+            "name": ["Nespresso - CitiZ & Milk Coffeemaker - Silver Chrome"],
+            "shortDescription": [
+              "Thermoblock heating element; froths hot or cold milk; 19-bar high-pressure pump; folding drip tray; cable storage"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "9373288",
+          "_score": 0.011805496,
+          "_source": {
+            "name": ["Bialetti - Moka Espresso Coffeemaker"],
+            "shortDescription": [
+              "Makes up to nine 2-oz. cups; durable aluminum material; unique octagon shape"
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "took": 45,
+    "timed_out": false,
+    "_shards": {
+      "total": 1,
+      "successful": 1,
+      "skipped": 0,
+      "failed": 0
+    },
+    "hits": {
+      "total": {
+        "value": 7359,
+        "relation": "eq"
+      },
+      "max_score": 439.58023,
+      "hits": [
+        {
+          "_index": "bbuy_products",
+          "_id": "1980124",
+          "_score": 439.58023,
+          "_source": {
+            "name": [
+              "Canon - EOS Rebel T3i 18.0-Megapixel DSLR Camera with 18-55mm Lens - Black"
+            ],
+            "shortDescription": [
+              "Vari-angle 3.0-inch Clear View LCD screen1080 full HD video3.7 FPS (frames per second)ISO 100-6400 (expandable to 12800)"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "1989073",
+          "_score": 370.2124,
+          "_source": {
+            "name": [
+              "Nikon - D5100 16.2-Megapixel DSLR Camera with 18-55mm VR Lens - Black"
+            ],
+            "shortDescription": [
+              "High Resolution 16.2 MP DX-format CMOS sensor3\" Super-Density Vari-Angle LCD Monitor1080 full HD videoISO sensitivity 100-6400 (expandable to ISO 25,600 equivalent)"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "6813362",
+          "_score": 193.7192,
+          "_source": {
+            "name": ["Canon - DSLR Gadget Bag - Black"],
+            "shortDescription": [
+              "Convenient storage for Canon EOS DSLR cameras"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "8297737",
+          "_score": 143.64357,
+          "_source": {
+            "name": ["Kodak - EasyShare 7.1-Megapixel Digital Camera - Black"],
+            "shortDescription": [
+              "12x optical/4.2x digital/50x total zoom; 2.5\" color TFT-LCD; direct-print capability; Kodak Color Science chip; burst shooting mode"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "8510961",
+          "_score": 115.59131,
+          "_source": {
+            "name": ["HP - Photosmart 7.2MP Digital Camera - White"],
+            "shortDescription": [
+              "3x optical/3x digital zoom; 2.4\" indoor/outdoor color LCD; HP Steady Photo shake reduction technology; 3 still-image quality modes; 9 picture modes; PictBridge-enabled"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "9924603",
+          "_score": 115.41877,
+          "_source": {
+            "name": ["Apple\u00ae - iPad\u2122 Digital Camera Connection Kit"],
+            "shortDescription": [
+              "Compatible with most digital cameras and Apple iPhone\u00ae; media reader; USB interface"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "1034553",
+          "_score": 107.97455,
+          "_source": {
+            "name": ["Rocketfish\u2122 - 58mm UV Filter"],
+            "shortDescription": [
+              "Compatible with most digital cameras with a 58mm lens; high-quality optical glass; improves image clarity"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "2053606",
+          "_score": 107.22141,
+          "_source": {
+            "name": ["Lowepro - Tahoe 30 Digital Camera Bag - Black"],
+            "shortDescription": [
+              "Compatible with most compact point-and-shoot digital cameras, select compact camcorders, MP3 players and mobile phones; velocity nylon construction; soft, brushed tricot lining; zippered front pocket"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "8510952",
+          "_score": 103.58807,
+          "_source": {
+            "name": ["Kodak - EasyShare 5.0MP Digital Camera - Pink"],
+            "shortDescription": [
+              "Best Buy Exclusive; 3x optical/5x digital zoom; 2.4\" color LCD; compact body; direct-print capability"
+            ]
+          }
+        },
+        {
+          "_index": "bbuy_products",
+          "_id": "4858397",
+          "_score": 103.51763,
+          "_source": {
+            "name": [
+              "Canon - PowerShot A2300 16.0-Megapixel Digital Camera - Black"
+            ],
+            "shortDescription": [
+              "5x optical/4x digital zoom2.7\" LCD screenHD movie modeDigital image stabilization"
+            ]
+          }
+        }
+      ]
+    }
+  }
+]


### PR DESCRIPTION
# Week2 - Project Assessment

## 1. For classifying product names to categories:

#### a) What precision (P@1) were you able to achieve?

**0.972 - 0.974**

#### b) What fastText parameters did you use?

`-lr 1.0 -epoch 25 -wordNgrams 2`

#### c) How did you transform the product names?

No transformation applied using "transform_name" method. When tested with transformation, achieved lower scores (~0.95).

#### d) How did you prune infrequent category labels, and how did that affect your precision?

Utilising pandas. Removing the category rows that has less than **min_products** products.

It had a huge impact, without pruning: 0.603, with prining: 0.97 - 0.972

#### e) How did you prune the category tree, and how did that affect your precision?

Utilising pandas. Replacing with the **nearest_parent** category that has more than **min_products** products.

It had a smaller impact comparing to pruning (but we are extending our category dictionary), always falling back to ancestors at depth 1: 0.909, final solution: 0.972 - 0.974

## 2. For deriving synonyms from content:

#### a) What were the results for your best model in the tokens used for evaluation?

Product Types

```
headphones:

headphon 0.848862
earbud 0.780217
ear 0.730387
earpollut 0.691522
yurbud 0.686955
phones 0.682976
cancelling 0.653936
over 0.639882
earphon 0.638961
piiq 0.635533
```

```
laptop:

notebook 0.767502
netbook 0.656412
bags 0.653984
ultrabook 0.636491
zenbook 0.627366
omnibook 0.620251
lifebook 0.613478
ibook 0.611688
briefcas 0.608474
t2060 0.602118
```

```
freezer:

freezerless 0.890927
refriger 0.803499
refrigerators 0.779358
refrigerator 0.774626
freez 0.770645
by 0.713044
cu 0.665524
side 0.658299
satina 0.657314
frost 0.648286
```

Brands

```
nintendo:

ds 0.968273
wii 0.932205
3ds 0.810575
nintendog 0.808966
gam 0.74554
xbox 0.720017
playstat 0.719159
psp 0.69107
360 0.676576
```

```
whirlpool:

maytag 0.775183
frigidair 0.771827
biscuit 0.750548
ge 0.721097
ingli 0.694863
hotpoint 0.687357
kitchenaid 0.676704
bisque 0.659302
electrolux 0.639224
amana 0.638293
```

```
kodak:

easyshar 0.856131
m341 0.711334
c813 0.684549
playsport 0.681347
m1063 0.677522
m763 0.676062
playtouch 0.670581
m340 0.66795
m550 0.663166
```

Models

```
ps2:

playstat 0.814385
ps3 0.729845
xbox 0.720434
gamecub 0.707921
guides 0.701105
psp 0.690421
gba 0.675813
gamecube 0.675015
guid 0.672131
adventur 0.66446
```

```
razr:

motorola 0.803692
droid 0.719096
cliphang 0.705777
cliq 0.704293
nokia 0.703014
r225 0.678673
phone 0.674843
startac 0.67105
cell 0.668403
ccm 0.660618
```

```
stratocaster:

telecaster 0.886299
fretboard 0.81337
strat 0.7886
starcaster 0.777565
fender 0.765122
squier 0.755677
tremolo 0.72126
thinlin 0.71435
whammy 0.710852
hss 0.69354
```

Other

```
holiday:

nobr 0.671777
stock 0.660111
congratul 0.587655
reindeer 0.585895
kwanzaa 0.583799
hallmark 0.578288
navidad 0.567146
perfectli 0.566057
slaphappi 0.554414
stardol 0.554159
```

```
plasma:

panel 0.700569
flat 0.688087
edtv 0.686464
tv 0.684522
hdtv 0.650581
ultravis 0.646992
viera 0.640964
kuro 0.639569
xbr 0.633605
ambilight 0.611085
```

```
leather:

reclin 0.682314
berklin 0.639976
dolan 0.627329
sofa 0.621712
faux 0.608956
armless 0.605202
case 0.604042
folio 0.566838
theaterseatstor 0.555563
sleev 0.552663
```

#### b) What fastText parameters did you use?

`-minCount 7 -epoch 25`, minCount 7 mostly to keep "nespresso", it had 8 occurences.

#### c) How did you transform the product names?

using **nltk word_tokenize, pos_tag, stopwords and stem**

## 3. For integrating synonyms with search:

#### a) How did you transform the product names (if different than previously)?

Same as level 2, using **nltk word_tokenize, pos_tag, stopwords and stem**

#### b) What threshold score did you use?

**0.75**

#### c) Were you able to find the additional results by matching synonyms?

Yes (you can see in "query_results.json" and "query_results_with_synonyms.json")

- "earbuds" => 1205 to 5852
- "nespresso" => 8 to 265
- "dslr" => 2837 to 7359

## 4. For classifying reviews:

#### a) What precision (P@1) were you able to achieve?

**0.88**

#### b) What fastText parameters did you use?

`-lr 1.0 -epoch 25 -wordNgrams 2`

#### c) How did you transform the review content?

No transformations. Tried only title or only comments, did not increase the precision.

#### d) How did you transform the review content?

Transforming rating to a different scale “positive”, “negative”, and “neutral” helped. P@1 is increased from **0.671** to **0.88**
